### PR TITLE
Changed Measure-Object -Property to Latency.

### DIFF
--- a/SpeedTester.psm1
+++ b/SpeedTester.psm1
@@ -86,7 +86,7 @@ function Start-SpeedTest
      
             try {
                 Write-Verbose "Testing ping to $server"
-                $test = (Test-Connection -ComputerName $server -Count 4 -ErrorAction Stop | measure-Object -Property ResponseTime -Average).average 
+                $test = (Test-Connection -ComputerName $server -Count 4 -ErrorAction Stop | measure-Object -Property Latency -Average).average 
                 $response = ($test -as [decimal] ) 
             }   
             catch [System.Net.NetworkInformation.PingException] {


### PR DESCRIPTION
Addresses the following error:

Measure-Object: C:\Users\joema\Documents\PowerShell\Modules\SpeedTester\1.2.0\SpeedTester.psm1:89
Line |
  89 |  … rAction Stop | measure-Object -Property ResponseTime -Average).averag …
     |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot process argument because the value of argument "Property" is not valid. Change the value of the
     | "Property" argument and run the operation again.

Changed Measure-Object -Property from 'ResponseTime' to 'Latency'.