### PR TITLE
Added backwards compatability.

### DIFF
--- a/SpeedTester.psm1
+++ b/SpeedTester.psm1
@@ -81,12 +81,19 @@ function Start-SpeedTest
             [Parameter(Mandatory=$true)]
             $servers 
         )
-
+        
+        if ($PSVersionTable.PSVersion.major -gt 5) {
+            $LatencyParam = 'Latency'
+        } 
+        else {
+            $LatencyParam = 'ResponseTime'
+        }
+        
         foreach ($server in $servers) { 
      
             try {
                 Write-Verbose "Testing ping to $server"
-                $test = (Test-Connection -ComputerName $server -Count 4 -ErrorAction Stop | measure-Object -Property Latency -Average).average 
+                $test = (Test-Connection -ComputerName $server -Count 4 -ErrorAction Stop | measure-Object -Property $LatencyParam -Average).average 
                 $response = ($test -as [decimal] ) 
             }   
             catch [System.Net.NetworkInformation.PingException] {


### PR DESCRIPTION
Test-Connection in Powershell 6 and 7 returns a TestConnectionCommand+PingReport object which has the Latency property. Test-Connection returns a Win32_PingStatus object which has the ResponseTime property. This change addresses this issue.